### PR TITLE
Add code lint provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,9 +9,9 @@
         "vscode": "^1.18.0"
     },
     "keywords": [
-      "Objective-J",
-      "objj",
-      "Cappuccino"
+        "Objective-J",
+        "objj",
+        "Cappuccino"
     ],
     "scripts": {
         "postinstall": "node ./node_modules/vscode/bin/install"
@@ -48,6 +48,7 @@
     },
     "devDependencies": {
         "@types/node": "^8.0.57",
+        "acorn-objj": "^1.1.3",
         "typescript": "^2.6.2",
         "vscode": "^1.1.10"
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,11 +1,21 @@
 import * as vscode from 'vscode';
 import { ObjjDocumentSymbolProvider } from './symbols';
+import { Linter } from './linter';
 
 const OBJJ_FILTER: vscode.DocumentFilter = { language: 'objj', scheme: 'file' };
 
 export function activate(context: vscode.ExtensionContext) {
+    // Symbol Provider
     let documentSymbolProvider: vscode.Disposable =
         vscode.languages.registerDocumentSymbolProvider(OBJJ_FILTER, new ObjjDocumentSymbolProvider());
-
     context.subscriptions.push(documentSymbolProvider);
+
+    // Linting Provider
+    let linter = new Linter();
+    linter.lintOpenFiles();
+    context.subscriptions.push(linter.diagnosticCollection);
+	context.subscriptions.push(
+		vscode.workspace.onDidOpenTextDocument(linter.lint, linter),
+		vscode.workspace.onDidSaveTextDocument(linter.lint, linter)
+    );
 }

--- a/src/linter.ts
+++ b/src/linter.ts
@@ -1,0 +1,39 @@
+import * as vscode from 'vscode';
+import * as acorn from 'acorn-objj';
+
+const packageJson = require('../package.json')
+const objjMarkdownId = "objj"
+const parser = acorn.parse;
+
+export class Linter {
+    public diagnosticCollection: vscode.DiagnosticCollection = null;
+
+    constructor() {
+        this.diagnosticCollection = vscode.languages.createDiagnosticCollection(packageJson.displayName)
+    }
+
+    public lintOpenFiles() {
+        (vscode.workspace.textDocuments || []).forEach(this.lint, this);
+    }
+
+    public lint(document: vscode.TextDocument): void {
+        const diagnostics: Array<vscode.Diagnostic> = [];
+
+        if (document.languageId != objjMarkdownId) {
+            return;
+        }
+
+        try {
+            parser.parse(document.getText());
+        } catch (e) {
+            let lineInfo = e.lineInfo;
+            let range = document.lineAt(lineInfo.line - 1).range;
+            let message = e.message;
+            let diagnostic = new vscode.Diagnostic(range, message, vscode.DiagnosticSeverity.Error);
+
+            diagnostics.push(diagnostic);
+        }
+
+        this.diagnosticCollection.set(document.uri, diagnostics);
+    }
+}


### PR DESCRIPTION
This pull request adds syntax checking for Objective-J via the acorn parser.
Currently the linter is triggered when a file is opened or changed.